### PR TITLE
Add Docker files needed for containerization

### DIFF
--- a/Backend/.gitignore
+++ b/Backend/.gitignore
@@ -1,4 +1,5 @@
 QuestionService/.env
+user-service/.env
 QuestionService/insert_questions_script.py
 
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.

--- a/Backend/QuestionService/.dockerignore
+++ b/Backend/QuestionService/.dockerignore
@@ -1,0 +1,6 @@
+# Ignore node_modules to prevent large files being included
+node_modules
+
+# Ignore Docker-related files themselves
+Dockerfile
+.dockerignore

--- a/Backend/QuestionService/Dockerfile
+++ b/Backend/QuestionService/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:20
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install
+
+COPY . .
+
+EXPOSE 3001
+CMD ["npm", "start"]

--- a/Backend/QuestionService/app.js
+++ b/Backend/QuestionService/app.js
@@ -17,4 +17,27 @@ mongoose.connect(mongoURI)
 
 app.use('/api/questions', questionRouter)
 
+app.get("/", (req, res, next) => {
+    console.log("Sending Greetings!");
+    res.json({
+      message: "Hello World from question-service",
+    });
+  });
+  
+// Handle When No Route Match Is Found
+app.use((req, res, next) => {
+    const error = new Error("Route Not Found");
+    error.status = 404;
+    next(error);
+});
+
+app.use((error, req, res, next) => {
+    res.status(error.status || 500);
+    res.json({
+      error: {
+        message: error.message,
+      },
+    });
+});
+
 module.exports = app

--- a/Backend/user-service/.dockerignore
+++ b/Backend/user-service/.dockerignore
@@ -1,0 +1,6 @@
+# Ignore node_modules to prevent large files being included
+node_modules
+
+# Ignore Docker-related files themselves
+Dockerfile
+.dockerignore

--- a/Backend/user-service/Dockerfile
+++ b/Backend/user-service/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:20
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install
+
+COPY . .
+
+EXPOSE 3002
+CMD ["npm", "start"]

--- a/Frontend/.dockerignore
+++ b/Frontend/.dockerignore
@@ -1,0 +1,6 @@
+# Ignore node_modules to prevent large files being included
+node_modules
+
+# Ignore Docker-related files themselves
+Dockerfile
+.dockerignore

--- a/Frontend/Dockerfile
+++ b/Frontend/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:20
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install
+
+COPY . .
+
+EXPOSE 3000
+CMD ["npm", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  question-service:
+    build:
+      context: ./Backend/QuestionService
+      dockerfile: Dockerfile
+    ports:
+      - "3001:3001"
+
+  user-service:
+    build:
+      context: ./Backend/user-service
+      dockerfile: Dockerfile
+    ports:
+      - "3002:3002"
+
+  frontend:
+    build:
+      context: ./Frontend
+      dockerfile: Dockerfile
+    ports:
+      - "3000:3000"


### PR DESCRIPTION
PeerPrep's services will be containerized, and it will be able to run by entering `docker-compose up --build` in the terminal at the root folder of the project (Ensure Docker is running beforehand).

Take note:
- Frontend will be on **port 3000**
- Question Service will be on **port 3001**
- User Service will be on **port 3002**